### PR TITLE
Fixed dbus screensaver prevention

### DIFF
--- a/io.github.rinigus.PureMaps.json
+++ b/io.github.rinigus.PureMaps.json
@@ -15,7 +15,8 @@
         "--talk-name=org.freedesktop.DBus",
         "--socket=pulseaudio",
         /* geoclue support */
-        "--system-talk-name=org.freedesktop.GeoClue2"
+        "--system-talk-name=org.freedesktop.GeoClue2",
+        "--talk-name=org.freedesktop.ScreenSaver"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
The screensaver prevention function is currently not working when the default session dbus whitelist is enabled.

The talk name for `org.freedesktop.ScreenSaver` is missing to enable screensaver prevention.

Tested using latest flatpak on phosh
using flatseal to modify and test
